### PR TITLE
Better API use

### DIFF
--- a/ocodo-mesh-grass-smt.el
+++ b/ocodo-mesh-grass-smt.el
@@ -40,32 +40,21 @@
   (ocodo:smt/overlay theme))
 
 (defun smt/ocodo-mesh-grass-buffer-name-style (widget)
-  (list :font-weight "normal"
-        :font-size "8pt"
-        :font-family "sans-serif"
-        :fill (if (smt/window-active-p) "#FFFFFF" "#666666")))
+  (list :fill (if (smt/window-active-p) "#FFFFFF" "#666666")))
 
 (defun smt/ocodo-mesh-grass-major-mode-style (widget)
-  (list :font-weight "normal"
-        :font-size "10pt"
-        :font-family "sans-serif"
+  (list :font-size "10pt"
         :fill (if (smt/window-active-p) "#AAAAAA" "#666666")))
 
 (defun smt/ocodo-mesh-grass-info-style (widget)
-  (list :font-weight "normal"
-        :font-size "6pt"
-        :font-family "sans-serif"
+  (list :font-size "6pt"
         :fill (if (smt/window-active-p) "#999999" "#555555")))
 
 (defun smt/ocodo-mesh-grass-position-info-style (widget)
-  (list :font-weight "normal"
-        :font-size "8pt"
-        :fill (if (smt/window-active-p) "#DDDDDD" "#999999")))
+  (list :fill (if (smt/window-active-p) "#DDDDDD" "#999999")))
 
 (defun smt/ocodo-mesh-grass-dirty-style (widget)
-  (list :font-weight "normal"
-        :font-size "9pt"
-        :font-family "sans-serif"
+  (list :font-size "9pt"
         :fill (if (and (or buffer-file-name buffer-offer-save) (buffer-modified-p))
                   ;; Dirty
                   (if (smt/window-active-p) "#FF6060" "#763030")
@@ -73,21 +62,20 @@
                 (if (smt/window-active-p) "#1F4F25" "#143519"))))
 
 (defun smt/ocodo-mesh-grass-minor-mode-style (widget)
-  (list :font-weight "normal"
-        :font-size "6pt"
+  (list :font-size "6pt"
         :fill (if (smt/window-active-p) "#FFFFFF" "#666666")))
 
 (defun smt/ocodo-mesh-grass-version-control-style (widget)
-  (list :font-weight "normal"
-        :font-size "8pt"
-        :font-family "sans-serif"
-        :fill (if (smt/window-active-p) "#60B18C" "#3D7058")))
+  (list :fill (if (smt/window-active-p) "#60B18C" "#3D7058")))
 
 (smt/deftheme ocodo-mesh-grass:smt
   :pixel-height 26
   :background 'ocodo-mesh-grass:smt/background
   :overlay    'ocodo-mesh-grass:smt/overlay
   :local-widgets
+  :style (list :font-family "sans-serif"
+               :font-weight "normal"
+               :font-size "8pt")
   ;;; Note order of widgets are determined by smt/defrows above.
   (list (cons 'major-mode
               (smt/make-widget

--- a/ocodo-mesh-grass-smt.el
+++ b/ocodo-mesh-grass-smt.el
@@ -72,11 +72,14 @@
   :pixel-height 26
   :background 'ocodo-mesh-grass:smt/background
   :overlay    'ocodo-mesh-grass:smt/overlay
-  :local-widgets
-  :style (list :font-family "sans-serif"
-               :font-weight "normal"
-               :font-size "8pt")
+  :style (lambda (theme)
+           (smt/combine-styles
+            (smt/t-style (smt/t-prototype theme))
+            (list :font-family "sans-serif"
+                  :font-weight "normal"
+                  :font-size "8pt")))
   ;;; Note order of widgets are determined by smt/defrows above.
+  :local-widgets
   (list (cons 'major-mode
               (smt/make-widget
                :prototype 'major-mode


### PR DESCRIPTION
An example of style inheritance (where widgets inherit styles from their theme and the row). Didn't test because I'm having some issues with the themes (could be my setup).

Some notes:
- You could use the same row settings between themes, subclassing when necessary.
- Please refrain from modifying the archetype, or overriding default functions -- you can get the same result by subclassing.
